### PR TITLE
Get gradient dimensions directly from screenshot

### DIFF
--- a/lock
+++ b/lock
@@ -10,11 +10,11 @@ fortune=$(expand -t 2 <(fortune -s))
 gradientColor='#E84C3D'
 
 # get gradient dimensions from the screenshot
-gradientDimensions=$(file $scr | cut -d, -f 2 | tr -d ' ') 
+read width height <<<$(file $scr | cut -d, -f 2 | tr -d ' ' | tr 'x' ' ')
 
 scrot "$scr"
 convert "$scr" -scale 10% -scale 1000%\
-	-size "$gradientDimensions" -gravity south-west \
+	-size "${width}x${height}" -gravity south-west \
 	gradient:none-"$gradientColor" -composite -matte \
 	"$icon" -gravity center -composite -matte \
 	-gravity center -pointsize 20 \

--- a/lock
+++ b/lock
@@ -6,9 +6,11 @@ icon="lock-icon.png"
 # font="$HOME/.local/share/fonts/Aller_Lt.ttf"
 # Expand is used to convert the tabs to spaces which
 # are handled better by imageMagick
-fortune=$(expand -t 2 <(fortune -s))
+fortune=$(expand -t 2 <(fortune))
 gradientColor='#E84C3D'
-gradientDimensions='1600x450'
+
+# get gradient dimensions from the screenshot
+gradientDimensions=$(file $scr | cut -d, -f 2 | tr -d ' ') 
 
 scrot "$scr"
 convert "$scr" -scale 10% -scale 1000%\

--- a/lock
+++ b/lock
@@ -6,7 +6,7 @@ icon="lock-icon.png"
 # font="$HOME/.local/share/fonts/Aller_Lt.ttf"
 # Expand is used to convert the tabs to spaces which
 # are handled better by imageMagick
-fortune=$(expand -t 2 <(fortune))
+fortune=$(expand -t 2 <(fortune -s))
 gradientColor='#E84C3D'
 
 # get gradient dimensions from the screenshot


### PR DESCRIPTION
Use `file`, `cut` and `tr` to ensure the gradient dimensions match the size of the file created by `scrot`.